### PR TITLE
set one_dimensional parameter to True

### DIFF
--- a/examples/1d_animation.py
+++ b/examples/1d_animation.py
@@ -14,6 +14,7 @@ bm = Model(
     num_blobs=20,
     t_drain=10,
     blob_factory=bf,
+    one_dimensional=True
 )
 
 ds = bm.make_realization(speed_up=True, error=1e-2)

--- a/examples/1d_animation.py
+++ b/examples/1d_animation.py
@@ -14,7 +14,7 @@ bm = Model(
     num_blobs=20,
     t_drain=10,
     blob_factory=bf,
-    one_dimensional=True
+    one_dimensional=True,
 )
 
 ds = bm.make_realization(speed_up=True, error=1e-2)


### PR DESCRIPTION
Since we have an explicit example for 1D we should use the `one_dimensional` parameter. 